### PR TITLE
Fix opensslError in demo/react-spa

### DIFF
--- a/demo/react-spa/package.json
+++ b/demo/react-spa/package.json
@@ -11,8 +11,8 @@
     "react-scripts": "3.4.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Hello!

When running the react-spa demo project a [well-known error](https://github.com/webpack/webpack/issues/15900) pops up. It can be reproduced for instance via `docker run --rm -p3000:3000 -it node:20 sh -c "git clone https://github.com/iMerica/dj-rest-auth.git && cd dj-rest-auth/demo/react-spa && yarn && yarn run start"`.
This PR adds one of the proposed workarounds from [webpack#15900](https://github.com/webpack/webpack/issues/15900).